### PR TITLE
Fixed package name in call to system.file().

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ We can go ahead and use the sample data provided with the package:
 
 ```splus
 # Get paths to sample files
-fg.path = system.file("extdata", "fg-data-ck2.txt", package="motifx")
-bg.path = system.file("extdata", "bg-data-serine.txt", package="motifx")
+fg.path = system.file("extdata", "fg-data-ck2.txt", package = "rmotifx")
+bg.path = system.file("extdata", "bg-data-serine.txt", package = "rmotifx")
 
 # Read in sequences
 fg.seqs = readLines(fg.path)


### PR DESCRIPTION
From [this question](https://www.biostars.org/p/235599/#235986) in Biostar I found that the example code in the README.md file cannot be run due to the package name mismatch. This fixes the problem. Also added space around `=` to match the rest of the file's style.